### PR TITLE
Enables querying Cloudsearch using simple Parser

### DIFF
--- a/lib/agnostic_backend.rb
+++ b/lib/agnostic_backend.rb
@@ -40,6 +40,8 @@ require 'agnostic_backend/queryable/cloudsearch/query'
 require 'agnostic_backend/queryable/cloudsearch/query_builder'
 require 'agnostic_backend/queryable/cloudsearch/result_set'
 require 'agnostic_backend/queryable/cloudsearch/visitor'
+require 'agnostic_backend/queryable/cloudsearch/simple_visitor'
+
 
 require 'agnostic_backend/cloudsearch/index'
 require 'agnostic_backend/cloudsearch/index_field'

--- a/lib/agnostic_backend/queryable/cloudsearch/executor.rb
+++ b/lib/agnostic_backend/queryable/cloudsearch/executor.rb
@@ -16,11 +16,13 @@ module AgnosticBackend
         def to_s
           result = ''
           result += "search?q=#{query_expression}" if query_expression
+          result += " filter=#{filter_query}" if filter_query
           result += " return=#{return_expression}" if return_expression
           result += " sort=#{sort}" if sort
           result += " size=#{size}" if size
           result += " offset=#{start}" if start
           result += " cursor=#{scroll_cursor}" if scroll_cursor
+          result += " parser=#{query_parser}"
           result
         end
 
@@ -44,11 +46,16 @@ module AgnosticBackend
 
         private
 
+        def filter_visitor
+          options[:filter_visitor]
+        end
+
         def client
           query.context.index.cloudsearch_domain_client
         end
 
         def filter_query
+          filter_expression.accept(filter_visitor) if filter_expression
         end
 
         def query_expression

--- a/lib/agnostic_backend/queryable/cloudsearch/executor.rb
+++ b/lib/agnostic_backend/queryable/cloudsearch/executor.rb
@@ -80,7 +80,12 @@ module AgnosticBackend
         end
 
         def query_parser
-          'structured'
+          case visitor
+          when SimpleVisitor
+            'simple'
+          else
+            'structured'
+          end
         end
 
         def return_expression

--- a/lib/agnostic_backend/queryable/cloudsearch/query.rb
+++ b/lib/agnostic_backend/queryable/cloudsearch/query.rb
@@ -3,9 +3,14 @@ module AgnosticBackend
     module Cloudsearch
       class Query < AgnosticBackend::Queryable::Query
 
-        def initialize(base)
+        def initialize(base, **options)
           super
-          @executor = Executor.new(self, Visitor.new)
+          case options[:parser]
+          when :simple
+            @executor = Executor.new(self, SimpleVisitor.new)
+          else
+            @executor = Executor.new(self, Visitor.new)
+          end
         end
 
         def execute

--- a/lib/agnostic_backend/queryable/cloudsearch/query.rb
+++ b/lib/agnostic_backend/queryable/cloudsearch/query.rb
@@ -7,9 +7,11 @@ module AgnosticBackend
           super
           case options[:parser]
           when :simple
-            @executor = Executor.new(self, SimpleVisitor.new)
+            @executor = Executor.new(self, SimpleVisitor.new, filter_visitor: Visitor.new)
+          when :structured
+            @executor = Executor.new(self, Visitor.new, filter_visitor: Visitor.new)
           else
-            @executor = Executor.new(self, Visitor.new)
+            @executor = Executor.new(self, Visitor.new, filter_visitor: Visitor.new)
           end
         end
 

--- a/lib/agnostic_backend/queryable/cloudsearch/query_builder.rb
+++ b/lib/agnostic_backend/queryable/cloudsearch/query_builder.rb
@@ -4,8 +4,8 @@ module AgnosticBackend
       class QueryBuilder < AgnosticBackend::Queryable::QueryBuilder
         private
 
-        def create_query(context)
-          AgnosticBackend::Queryable::Cloudsearch::Query.new(context)
+        def create_query(context, **options)
+          AgnosticBackend::Queryable::Cloudsearch::Query.new(context, **options)
         end
       end
     end

--- a/lib/agnostic_backend/queryable/cloudsearch/simple_visitor.rb
+++ b/lib/agnostic_backend/queryable/cloudsearch/simple_visitor.rb
@@ -1,0 +1,130 @@
+module AgnosticBackend
+  module Queryable
+    module Cloudsearch
+      class SimpleVisitor < AgnosticBackend::Queryable::Visitor
+
+        private
+
+        def visit_criteria_equal(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_not_equal(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_greater(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_less(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_greater_equal(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_less_equal(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_greater_and_less(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_greater_equal_and_less(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_greater_and_less_equal(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_greater_equal_and_less_equal(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_contains(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_criteria_starts(subject)
+          raise UnsupportedAttributeError unless subject.attribute.any?
+          "#{visit(subject.value)}*"
+        end
+
+        def visit_criteria_free_text(subject)
+          raise UnsupportedAttributeError unless subject.attribute.any?
+          "#{visit(subject.value)}"
+        end
+
+        def visit_criteria_fuzzy(subject)
+          raise UnsupportedAttributeError unless subject.attribute.any?
+          "#{visit(subject.value)}~#{subject.fuzziness}"
+        end
+
+        def visit_operations_not(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_operations_and(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_operations_or(subject)
+          raise UnsupportedNodeError
+        end
+
+        def visit_operations_ascending(subject)
+          "#{visit(subject.attribute)} asc"
+        end
+
+        def visit_operations_descending(subject)
+          "#{visit(subject.attribute)} desc"
+        end
+
+        def visit_query(subject)
+          "#{subject.children.map{|c| visit(c)}.join(' ')}"
+        end
+
+        def visit_expressions_where(subject)
+          visit(subject.criterion) #search?q=
+        end
+
+        def visit_expressions_select(subject)
+          "#{subject.projections.map{|c| visit(c)}.join(',')}" #return=
+        end
+
+        def visit_expressions_order(subject)
+          "#{subject.qualifiers.map{|c| visit(c)}.join(',')}" #sort=
+        end
+
+        def visit_expressions_limit(subject)
+          visit(subject.limit) #size=
+        end
+
+        def visit_expressions_offset(subject)
+          visit(subject.offset) #offset=
+        end
+
+        def visit_expressions_scroll_cursor(subject)
+          visit(subject.scroll_cursor)  #cursor=
+        end
+
+        def visit_attribute(subject)
+          subject.name.split('.').join('__')
+        end
+
+        def visit_value(subject)
+          case subject.type
+          when :string,:string_array,:text,:text_array
+            subject.value
+          else
+            subject.value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/agnostic_backend/queryable/cloudsearch/visitor.rb
+++ b/lib/agnostic_backend/queryable/cloudsearch/visitor.rb
@@ -89,6 +89,10 @@ module AgnosticBackend
           visit(subject.criterion) #search?q=
         end
 
+        def visit_expressions_filter(subject)
+          visit(subject.criterion)
+        end
+
         def visit_expressions_select(subject)
           "#{subject.projections.map{|c| visit(c)}.join(',')}" #return=
         end

--- a/lib/agnostic_backend/queryable/criteria/binary.rb
+++ b/lib/agnostic_backend/queryable/criteria/binary.rb
@@ -45,6 +45,15 @@ module AgnosticBackend
 
       class FreeText < Relational;
       end
+
+      class Fuzzy < Relational
+        attr_reader :fuzziness
+
+        def initialize(attribute:, value:, context: nil, fuzziness: 1)
+          @fuzziness = fuzziness
+          super(attribute: attribute, value: value, context: context)
+        end
+      end
     end
   end
 end

--- a/lib/agnostic_backend/queryable/criteria_builder.rb
+++ b/lib/agnostic_backend/queryable/criteria_builder.rb
@@ -60,6 +60,10 @@ module AgnosticBackend
         Criteria::FreeText.new(attribute: attribute, value: value, context: context)
       end
 
+      def fuzzy(attribute, value, fuzziness)
+        Criteria::Fuzzy.new(attribute: attribute, value: value, context: context, fuzziness: fuzziness)
+      end
+
       def asc(attribute)
         Operations::Ascending.new(attribute: attribute, context: context)
       end

--- a/lib/agnostic_backend/queryable/elasticsearch/query.rb
+++ b/lib/agnostic_backend/queryable/elasticsearch/query.rb
@@ -3,7 +3,7 @@ module AgnosticBackend
     module Elasticsearch
       class Query < AgnosticBackend::Queryable::Query
 
-        def initialize(base)
+        def initialize(base, **options)
           super
           @executor = Executor.new(self, Visitor.new)
         end

--- a/lib/agnostic_backend/queryable/elasticsearch/query_builder.rb
+++ b/lib/agnostic_backend/queryable/elasticsearch/query_builder.rb
@@ -4,8 +4,8 @@ module AgnosticBackend
       class QueryBuilder < AgnosticBackend::Queryable::QueryBuilder
         private
 
-        def create_query(context)
-          AgnosticBackend::Queryable::Elasticsearch::Query.new(context)
+        def create_query(context, **options)
+          AgnosticBackend::Queryable::Elasticsearch::Query.new(context, **options)
         end
       end
     end

--- a/lib/agnostic_backend/queryable/executor.rb
+++ b/lib/agnostic_backend/queryable/executor.rb
@@ -4,9 +4,12 @@ module AgnosticBackend
 
       attr_reader :query
       attr_reader :visitor
+      attr_reader :options
 
-      def initialize(query, visitor)
-        @query, @visitor = query, visitor
+      def initialize(query, visitor, **options)
+        @query = query
+        @visitor = visitor
+        @options = options
       end
 
       def execute
@@ -37,6 +40,10 @@ module AgnosticBackend
 
       def scroll_cursor_expression
         query.children.find { |e| e.is_a? Expressions::ScrollCursor }
+      end
+
+      def filter_expression
+        query.children.find { |e| e.is_a? Expressions::Filter }
       end
     end
   end

--- a/lib/agnostic_backend/queryable/expressions/expression.rb
+++ b/lib/agnostic_backend/queryable/expressions/expression.rb
@@ -14,6 +14,17 @@ module AgnosticBackend
         end
       end
 
+
+      class Filter < Expression
+        def initialize(criterion:, context:)
+          super([criterion], context)
+        end
+
+        def criterion
+          children.first
+        end
+      end
+
       class Select < Expression
         def initialize(attributes:, context:)
           super(attributes.map { |a| Attribute.new(a, parent: self, context: context) }, context)

--- a/lib/agnostic_backend/queryable/query.rb
+++ b/lib/agnostic_backend/queryable/query.rb
@@ -4,11 +4,13 @@ module AgnosticBackend
       attr_accessor :errors
       attr_reader :context
       attr_reader :executor
+      attr_reader :options
 
       def initialize(context, **options)
         super()
         @errors ||= Hash.new { |hash, key| hash[key] = Array.new }
         @context = context
+        @options = options
       end
 
       def execute

--- a/lib/agnostic_backend/queryable/query.rb
+++ b/lib/agnostic_backend/queryable/query.rb
@@ -3,8 +3,9 @@ module AgnosticBackend
     class Query < TreeNode
       attr_accessor :errors
       attr_reader :context
+      attr_reader :executor
 
-      def initialize(context)
+      def initialize(context, **options)
         super()
         @errors ||= Hash.new { |hash, key| hash[key] = Array.new }
         @context = context

--- a/lib/agnostic_backend/queryable/query_builder.rb
+++ b/lib/agnostic_backend/queryable/query_builder.rb
@@ -43,6 +43,11 @@ module AgnosticBackend
         self
       end
 
+      def filter(filter)
+        @filter = filter
+        self
+      end
+
       def build(**options)
         query = create_query(self, **options)
         query.children << build_where_expression if @criterion
@@ -50,6 +55,7 @@ module AgnosticBackend
         query.children << build_order_expression if @order_qualifiers
         query.children << build_limit_expression if @limit
         query.children << build_offset_expression if @offset
+        query.children << build_filter_expression if @filter
         query.children << build_scroll_cursor_expression if @scroll_cursor
 
         @query = query
@@ -63,6 +69,10 @@ module AgnosticBackend
 
       def build_where_expression
         Expressions::Where.new(criterion: @criterion, context: self)
+      end
+
+      def build_filter_expression
+        Expressions::Filter.new(criterion: @filter, context: self)
       end
 
       def build_select_expression

--- a/lib/agnostic_backend/queryable/query_builder.rb
+++ b/lib/agnostic_backend/queryable/query_builder.rb
@@ -43,8 +43,8 @@ module AgnosticBackend
         self
       end
 
-      def build
-        query = create_query(self)
+      def build(**options)
+        query = create_query(self, **options)
         query.children << build_where_expression if @criterion
         query.children << build_select_expression if @projections
         query.children << build_order_expression if @order_qualifiers
@@ -57,7 +57,7 @@ module AgnosticBackend
 
       private
 
-      def create_query(context)
+      def create_query(context, **options)
         raise NotImplementedError, 'AbstractMethod'
       end
 

--- a/lib/agnostic_backend/queryable/validator.rb
+++ b/lib/agnostic_backend/queryable/validator.rb
@@ -84,6 +84,11 @@ module AgnosticBackend
         visit(subject.value)
       end
 
+      def visit_criteria_fuzzy(subject)
+        visit(subject.attribute)
+        visit(subject.value)
+      end
+
       def visit_operations_not(subject)
         visit(subject.operand)
       end

--- a/lib/agnostic_backend/queryable/validator.rb
+++ b/lib/agnostic_backend/queryable/validator.rb
@@ -113,6 +113,10 @@ module AgnosticBackend
         visit(subject.criterion)
       end
 
+      def visit_expressions_filter(subject)
+        visit(subject.criterion)
+      end
+
       def visit_expressions_select(subject)
         subject.projections.each { |c| visit(c) }
       end

--- a/lib/agnostic_backend/queryable/visitor.rb
+++ b/lib/agnostic_backend/queryable/visitor.rb
@@ -99,6 +99,10 @@ module AgnosticBackend
         raise NotImplementedError
       end
 
+      def visit_expressions_filter(subject)
+        raise NotImplementedError
+      end
+
       def visit_expressions_select(subject)
         raise NotImplementedError
       end

--- a/lib/agnostic_backend/queryable/visitor.rb
+++ b/lib/agnostic_backend/queryable/visitor.rb
@@ -1,5 +1,8 @@
 module AgnosticBackend
   module Queryable
+    class UnsupportedNodeError < StandardError; end
+    class UnsupportedAttributeError < StandardError; end
+
     class Visitor
       def visit(subject)
         method_name = class_to_method_name(subject.class)

--- a/spec/queryable/cloudsearch/executor_spec.rb
+++ b/spec/queryable/cloudsearch/executor_spec.rb
@@ -20,8 +20,9 @@ describe AgnosticBackend::Queryable::Cloudsearch::Executor do
   let(:context) { double("Context", index: index) }
   let(:query) { double("Query", base: builder, context: context) }
   let(:visitor) { double('Visitor') }
+  let(:filter_visitor) { double('FilterVisitor') }
 
-  subject { AgnosticBackend::Queryable::Cloudsearch::Executor.new(query, visitor)}
+  subject { AgnosticBackend::Queryable::Cloudsearch::Executor.new(query, visitor, filter_visitor: filter_visitor) }
 
   describe '#execute' do
     let(:client) { double("Client") }
@@ -45,6 +46,12 @@ describe AgnosticBackend::Queryable::Cloudsearch::Executor do
   end
 
   describe '#filter_query' do
+    it 'should return where clause evaluation' do
+      filter_expression = double('FilterExpression')
+      expect(subject).to receive(:filter_expression).twice.and_return(filter_expression)
+      expect(filter_expression).to receive(:accept).with(filter_visitor).and_return('(field=attribute value)')
+      expect(subject.send(:filter_query)).to eq '(field=attribute value)'
+    end
   end
 
   describe '#query_expression' do
@@ -62,6 +69,17 @@ describe AgnosticBackend::Queryable::Cloudsearch::Executor do
       expect(subject).to receive(:offset_expression).twice.and_return(offset)
       expect(offset).to receive(:accept).with(visitor).and_return(1)
       expect(subject.send(:start)).to eq 1
+    end
+  end
+
+  describe '#filter_visitor' do
+    let(:visitor) { double('Visitor') }
+    let(:filter_visitor) { double('FilterVisitor') }
+
+    subject { AgnosticBackend::Queryable::Cloudsearch::Executor.new(query, visitor, filter_visitor: filter_visitor) }
+
+    it 'should return the filter_visitor' do
+      expect(subject.send(:filter_visitor)).to eq filter_visitor
     end
   end
 

--- a/spec/queryable/cloudsearch/executor_spec.rb
+++ b/spec/queryable/cloudsearch/executor_spec.rb
@@ -87,8 +87,18 @@ describe AgnosticBackend::Queryable::Cloudsearch::Executor do
   end
 
   describe '#query_parser' do
-    it 'should return \'structured\'' do
-      expect(subject.send(:query_parser)).to eq 'structured'
+    context 'when visitor is SimpleVisitor' do
+      subject { AgnosticBackend::Queryable::Cloudsearch::Executor.new(query, AgnosticBackend::Queryable::Cloudsearch::SimpleVisitor.new)}
+      it 'should return \'simple\'' do
+        expect(subject.send(:query_parser)).to eq 'simple'
+      end
+    end
+
+    context 'when visitor is not SimpleVisitor' do
+      subject { AgnosticBackend::Queryable::Cloudsearch::Executor.new(query, AgnosticBackend::Queryable::Cloudsearch::Visitor.new)}
+      it 'should return \'structured\'' do
+        expect(subject.send(:query_parser)).to eq 'structured'
+      end
     end
   end
 

--- a/spec/queryable/cloudsearch/query_spec.rb
+++ b/spec/queryable/cloudsearch/query_spec.rb
@@ -4,15 +4,17 @@ describe AgnosticBackend::Queryable::Cloudsearch::Query do
   let(:base) { double('Base') }
   context 'when parser option is set to :simple' do
     subject { AgnosticBackend::Queryable::Cloudsearch::Query.new(base, parser: :simple) }
-    it 'should use the SimpleVisitor' do
+    it 'should use the SimpleVisitor as query visitor and Visitor as filter visitor' do
       expect(subject.executor.visitor).to be_a AgnosticBackend::Queryable::Cloudsearch::SimpleVisitor
+      expect(subject.executor.send(:filter_visitor)).to be_a AgnosticBackend::Queryable::Cloudsearch::Visitor
     end
   end
 
   context 'when parser option is not set' do
     subject { AgnosticBackend::Queryable::Cloudsearch::Query.new(base) }
-    it 'should use the Visitor' do
+    it 'should use the Visitor as query visitor and Visitor as filter visitor' do
       expect(subject.executor.visitor).to be_a AgnosticBackend::Queryable::Cloudsearch::Visitor
+      expect(subject.executor.send(:filter_visitor)).to be_a AgnosticBackend::Queryable::Cloudsearch::Visitor
     end
   end
 end

--- a/spec/queryable/cloudsearch/query_spec.rb
+++ b/spec/queryable/cloudsearch/query_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe AgnosticBackend::Queryable::Cloudsearch::Query do
+  let(:base) { double('Base') }
+  context 'when parser option is set to :simple' do
+    subject { AgnosticBackend::Queryable::Cloudsearch::Query.new(base, parser: :simple) }
+    it 'should use the SimpleVisitor' do
+      expect(subject.executor.visitor).to be_a AgnosticBackend::Queryable::Cloudsearch::SimpleVisitor
+    end
+  end
+
+  context 'when parser option is not set' do
+    subject { AgnosticBackend::Queryable::Cloudsearch::Query.new(base) }
+    it 'should use the Visitor' do
+      expect(subject.executor.visitor).to be_a AgnosticBackend::Queryable::Cloudsearch::Visitor
+    end
+  end
+end

--- a/spec/queryable/cloudsearch/simple_visitor_spec.rb
+++ b/spec/queryable/cloudsearch/simple_visitor_spec.rb
@@ -1,0 +1,187 @@
+require 'spec_helper'
+
+describe AgnosticBackend::Queryable::Cloudsearch::SimpleVisitor do
+
+  let(:schema) do
+    {
+        'an_integer' => double('FieldType', type: :integer),
+        'a_string' => double('FieldType', type: :string),
+        'a_date' => double('FieldType', type: :date)
+    }
+  end
+  let(:index) { double('Index', schema: schema) }
+  let(:context) { double('Context', index: index) }
+
+  context 'binary criterion' do
+    describe '#visit_criteria_starts' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Criteria::Starts.new(attribute: '*', value: 'value', context: context)}
+      it 'should evaluate to value*' do
+        expect(subject).to receive(:visit_criteria_starts).and_call_original
+        expect(subject.visit(visitor_subject)).to eq "value*"
+      end
+    end
+
+    describe '#visit_criteria_fuzzy' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Criteria::Fuzzy.new(attribute: '*', value: 'value', context: context, fuzziness: 2)}
+      it 'should evaluate to value~fuzziness' do
+        expect(subject).to receive(:visit_criteria_fuzzy).and_call_original
+        expect(subject.visit(visitor_subject)).to eq "value~2"
+      end
+    end
+
+    describe '#visit_criteria_free_text' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Criteria::FreeText.new(attribute: '*', value: 'value', context: context)}
+      it 'should evaluate to value' do
+        expect(subject).to receive(:visit_criteria_free_text).and_call_original
+        expect(subject.visit(visitor_subject)).to eq "value"
+      end
+    end
+  end
+
+  context 'unary criterion' do
+    describe '#visit_operations_ascending' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Operations::Ascending.new(attribute: 'an_integer', context: context)}
+      it 'should evaluate to attribute asc' do
+        expect(subject).to receive(:visit_operations_ascending).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'an_integer asc'
+      end
+    end
+
+    describe '#visit_operations_descending' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Operations::Descending.new(attribute: 'an_integer', context: context)}
+      it 'should evaluate to attribute desc' do
+        expect(subject).to receive(:visit_operations_descending).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'an_integer desc'
+      end
+    end
+  end
+
+
+  describe '#visit_query' do
+    let(:base) { double('Base') }
+    let(:child_1) { double('child_1', children: []) }
+    let(:child_2) { double('child_2', children: []) }
+
+    before do
+      allow(subject).to receive(:visit).with(any_args).and_call_original
+      allow(subject).to receive(:visit).with(child_1).and_return 'child_1'
+      allow(subject).to receive(:visit).with(child_2).and_return 'child_2'
+    end
+
+    it 'should evaluate to child1 child2 child3' do
+      visitor_subject = AgnosticBackend::Queryable::Query.new(base)
+      visitor_subject.children << child_1
+      visitor_subject.children << child_2
+      expect(subject).to receive(:visit_query).and_call_original
+      expect(subject.visit(visitor_subject)).to eq 'child_1 child_2'
+    end
+  end
+
+  context 'expressions' do
+    describe '#visit_expressions_where' do
+      let(:fuzzy_criterion) { AgnosticBackend::Queryable::Criteria::Fuzzy.new(attribute: '*', value: 'abcde', context: context, fuzziness: 2)}
+      let(:visitor_subject) { AgnosticBackend::Queryable::Expressions::Where.new(criterion: fuzzy_criterion, context: context)}
+
+      it 'should evaluate to value~fuzziness' do
+        expect(subject).to receive(:visit_expressions_where).and_call_original
+        expect(subject.visit(visitor_subject)).to eq "abcde~2"
+      end
+    end
+
+    describe '#visit_expressions_select' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Expressions::Select.new(attributes: ['an_integer','a_string','a_date'], context: context)}
+
+      it 'should evaluate to projection1,projection2,projection3' do
+        expect(subject).to receive(:visit_expressions_select).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'an_integer,a_string,a_date'
+      end
+    end
+
+    describe '#visit_expressions_order' do
+      let(:qualifiers_1) { AgnosticBackend::Queryable::Operations::Ascending.new(attribute: 'an_integer', context: context)}
+      let(:qualifiers_2) { AgnosticBackend::Queryable::Operations::Descending.new(attribute: 'a_string', context: context)}
+      let(:visitor_subject) { AgnosticBackend::Queryable::Expressions::Order.new(attributes: [qualifiers_1, qualifiers_2], context: context)}
+
+      it 'should evaluate to ordering1,ordering2,ordering3' do
+        expect(subject).to receive(:visit_expressions_order).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'an_integer asc,a_string desc'
+      end
+    end
+
+    describe '#visit_expressions_limit' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Expressions::Limit.new(value: 10, context: context)}
+
+      it 'should evaluate to value' do
+        expect(subject).to receive(:visit_expressions_limit).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 10
+      end
+    end
+
+    describe '#visit_expressions_offset' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Expressions::Offset.new(value: 10, context: context)}
+
+      it 'should evaluate to size=1' do
+        expect(subject).to receive(:visit_expressions_offset).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 10
+      end
+    end
+
+    describe '#visit_cloudsearch_expressions_cursor' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Expressions::ScrollCursor.new(value: 'scroll_cursor', context: context)}
+
+      it 'should evaluate to cursor=abcdef' do
+        expect(subject).to receive(:visit_expressions_scroll_cursor).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'scroll_cursor'
+      end
+    end
+  end
+
+  describe '#visit_value' do
+    let(:parent) { double('Parent') }
+
+    context 'when attribute\'s type is string' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Value.new('value', parent: parent, context: context)}
+      it 'should evaluate to \'value\'' do
+        expect(visitor_subject).to receive(:type).and_return(:string)
+        expect(subject).to receive(:visit_value).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'value'
+      end
+    end
+
+    context 'when attribute\'s type is string array' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Value.new('value', parent: parent, context: context)}
+      it 'should evaluate to \'value\'' do
+        expect(visitor_subject).to receive(:type).and_return(:string_array)
+        expect(subject).to receive(:visit_value).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'value'
+      end
+    end
+
+    context 'when attribute\'s type is text' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Value.new('value', parent: parent, context: context) }
+      it 'should evaluate to \'value\'' do
+        expect(visitor_subject).to receive(:type).and_return(:text)
+        expect(subject).to receive(:visit_value).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'value'
+      end
+    end
+
+    context 'when attribute\'s type is text array' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Value.new('value', parent: parent, context: context) }
+      it 'should evaluate to \'value\'' do
+        expect(visitor_subject).to receive(:type).and_return(:text_array)
+        expect(subject).to receive(:visit_value).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'value'
+      end
+    end
+
+    context 'when attribute\'s type is not defined' do
+      let(:visitor_subject) { AgnosticBackend::Queryable::Value.new('value', parent: parent, context: context) }
+      it 'should evaluate to value' do
+        expect(visitor_subject).to receive(:type).and_return(nil)
+        expect(subject).to receive(:visit_value).and_call_original
+        expect(subject.visit(visitor_subject)).to eq 'value'
+      end
+    end
+  end
+end

--- a/spec/queryable/criteria/binary_spec.rb
+++ b/spec/queryable/criteria/binary_spec.rb
@@ -60,9 +60,17 @@ describe AgnosticBackend::Queryable::Criteria::Binary do
     end
 
     context 'FreeText Criterion' do
-      let(:equal_criterion) { AgnosticBackend::Queryable::Criteria::FreeText.new(attribute: attribute, value: value, context: context) }
+      let(:free_text_criterion) { AgnosticBackend::Queryable::Criteria::FreeText.new(attribute: attribute, value: value, context: context) }
       it 'should inherit from Relational criterion' do
-        expect(equal_criterion).to be_a_kind_of AgnosticBackend::Queryable::Criteria::Relational
+        expect(free_text_criterion).to be_a_kind_of AgnosticBackend::Queryable::Criteria::Relational
+      end
+    end
+
+    context 'Fuzzy Criterion' do
+      let(:fuzzy_criterion) { AgnosticBackend::Queryable::Criteria::Fuzzy.new(attribute: attribute, value: value, context: context, fuzziness: 2) }
+      it 'should inherit from Relational criterion' do
+        expect(fuzzy_criterion).to be_a_kind_of AgnosticBackend::Queryable::Criteria::Relational
+        expect(fuzzy_criterion.fuzziness).to eq 2
       end
     end
 

--- a/spec/queryable/criteria_builder_spec.rb
+++ b/spec/queryable/criteria_builder_spec.rb
@@ -61,6 +61,20 @@ describe AgnosticBackend::Queryable::CriteriaBuilder do
     end
   end
 
+  describe '#free_text' do
+    it 'should initialize an FreeText criterion' do
+      expect(AgnosticBackend::Queryable::Criteria::FreeText).to receive(:new).with(attribute: '*', value: 'abcde', context: context).and_call_original
+      expect(subject.free_text('*', 'abcde')).to be_a(AgnosticBackend::Queryable::Criteria::FreeText)
+    end
+  end
+
+  describe '#fuzzy' do
+    it 'should initialize an Fuzzy criterion' do
+      expect(AgnosticBackend::Queryable::Criteria::Fuzzy).to receive(:new).with(attribute: '*', value: 'abcde', context: context, fuzziness: 2).and_call_original
+      expect(subject.fuzzy('*', 'abcde', 2)).to be_a(AgnosticBackend::Queryable::Criteria::Fuzzy)
+    end
+  end
+
   describe '#neq' do
     it 'should initialize a NotEqual criterion' do
       expect(AgnosticBackend::Queryable::Criteria::NotEqual).to receive(:new).with(attribute: 'an_integer', value: 1, context: context).and_call_original

--- a/spec/queryable/expressions/expression_spec.rb
+++ b/spec/queryable/expressions/expression_spec.rb
@@ -35,6 +35,25 @@ describe AgnosticBackend::Queryable::Expressions::Expression do
     end
   end
 
+  context 'Filter Expression' do
+    let(:an_equal_filter) { AgnosticBackend::Queryable::Criteria::Equal.new(attribute: 'an_integer', value: 10, context: context)}
+    let(:a_not_equal_filter) { AgnosticBackend::Queryable::Criteria::Equal.new(attribute: 'a_string', value: 'value', context: context)}
+    let(:and_filter) { AgnosticBackend::Queryable::Operations::And.new(operands: [an_equal_filter, a_not_equal_filter], context: context)}
+    let(:filter_expression) { AgnosticBackend::Queryable::Expressions::Filter.new(criterion: and_filter, context: context)}
+
+    it 'should inherit from Expression' do
+      expect(filter_expression).to be_a_kind_of AgnosticBackend::Queryable::Expressions::Expression
+    end
+
+    context 'aliases' do
+      describe '#criterion' do
+        it 'should be the first children' do
+          expect(filter_expression.criterion).to eq(filter_expression.children.first)
+        end
+      end
+    end
+  end
+
   context 'Select Expression' do
     let(:projections) { ['an_integer','a_string','a_date'] }
     let(:select_expression) { AgnosticBackend::Queryable::Expressions::Select.new(attributes: [projections], context: context) }

--- a/spec/queryable/query_builder_spec.rb
+++ b/spec/queryable/query_builder_spec.rb
@@ -106,7 +106,7 @@ describe AgnosticBackend::Queryable::QueryBuilder do
     let(:query) { double('Query', children: [])}
 
     it 'should build query' do
-      expect(subject).to receive(:create_query).with(subject).and_return(query)
+      expect(subject).to receive(:create_query).with(subject, {}).and_return(query)
       expect(subject.build).to eq query
     end
 

--- a/spec/queryable/query_builder_spec.rb
+++ b/spec/queryable/query_builder_spec.rb
@@ -24,6 +24,15 @@ describe AgnosticBackend::Queryable::QueryBuilder do
     end
   end
 
+  describe '#filter' do
+    let(:filter) { double('Filter') }
+
+    it 'should assign argument to filter instance variable' do
+      expect(subject.filter(filter)).to eq subject
+      expect(subject.instance_variable_get(:@filter)).to eq filter
+    end
+  end
+
   describe '#select' do
     let(:projections) { ['a'] }
 
@@ -120,6 +129,19 @@ describe AgnosticBackend::Queryable::QueryBuilder do
 
         expect(subject.build).to eq query
         expect(query.children.first).to eq where_expression
+      end
+    end
+
+    context 'when filter instance variable is defined' do
+      let(:filter) { double('filter') }
+      let(:filter_expression) { double('FilterExpression') }
+
+      it 'should build a filter expression and append to query\'s children' do
+        subject.instance_variable_set(:@filter, filter)
+        expect(subject).to receive(:build_filter_expression).and_return filter_expression
+
+        expect(subject.build).to eq query
+        expect(query.children.first).to eq filter_expression
       end
     end
 


### PR DESCRIPTION
The reason behind evaluating queries for `simple` query parser of Cloudsearch, 
is to enable `fuzzy` searching capabilities 
(as described [here](http://docs.aws.amazon.com/cloudsearch/latest/developerguide/searching-text.html) - "You can also perform fuzzy searches with the simple query parser")

Queries made using `simple` query parser are executed only for all text and text-array fields.

All interfaces are backwards compatible.

In order to use the `simple` query parser a client should use the following syntax:
`query = query_builder.build(parser: :simple)`

A new `fuzzy` node was added that can be created using the following syntax:
`criteria = criteria_builder.fuzzy('*', '45678910', 3)`
