### PR TITLE
Changes activesupport required version to >3, <5

### DIFF
--- a/agnostic_backend.gemspec
+++ b/agnostic_backend.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.1.0' # for mandatory method keyword arguments
 
-  spec.add_runtime_dependency "activesupport", "~>3"
+  spec.add_runtime_dependency "activesupport", ">3", "<5"
   spec.add_runtime_dependency "aws-sdk", "~> 2"
   spec.add_runtime_dependency "faraday"
 


### PR DESCRIPTION
Since the only notable change in active support 4 is Object#try I don't see any reason of locking the gem to ActiveSupport ~>3. Checking Rails 5 release notes we can also require Just greater that ActiveSupport 3 version. 
