### PR TITLE
Adds ability to get an array of generated indexables before publishing.

### DIFF
--- a/lib/agnostic_backend/cloudsearch/indexer.rb
+++ b/lib/agnostic_backend/cloudsearch/indexer.rb
@@ -22,7 +22,6 @@ module AgnosticBackend
         publish_all(documents)
       end
 
-      private
 
       def publish(document)
         publish_all([document])
@@ -39,6 +38,8 @@ module AgnosticBackend
           )
         end
       end
+
+      private
 
       def client
         index.cloudsearch_domain_client

--- a/lib/agnostic_backend/elasticsearch/indexer.rb
+++ b/lib/agnostic_backend/elasticsearch/indexer.rb
@@ -3,12 +3,6 @@ module AgnosticBackend
     class Indexer < AgnosticBackend::Indexer
       include AgnosticBackend::Utilities
 
-      private
-
-      def client
-        index.client
-      end
-
       def publish(document)
         client.send_request(:put,
                             path: "/#{index.index_name}/#{index.type}/#{document["id"]}",
@@ -26,6 +20,11 @@ module AgnosticBackend
         response
       end
 
+      private
+
+      def client
+        index.client
+      end
 
       def prepare(document)
         raise IndexingError.new, "Document does not have an ID field" unless document["id"].present?

--- a/lib/agnostic_backend/indexer.rb
+++ b/lib/agnostic_backend/indexer.rb
@@ -21,10 +21,16 @@ module AgnosticBackend
     # @param [Indexable] an Indexable object
     def put_all(indexables)
       documents = indexables.map do |indexable|
-        transform(prepare(indexable.generate_document))
+        generate_document(indexable)
       end
       documents.reject!(&:empty?)
+
       publish_all(documents) unless documents.empty?
+    end
+
+    # @param [Indexable] an Indexable object
+    def generate_document(indexable)
+      transform(prepare(indexable.generate_document))
     end
 
     # Deletes the specified document from the index
@@ -41,8 +47,6 @@ module AgnosticBackend
       raise NotImplementedError
     end
 
-    private
-
     def publish(document)
       publish_all([document])
     end
@@ -50,6 +54,8 @@ module AgnosticBackend
     def publish_all(documents)
       raise NotImplementedError
     end
+
+    private
 
     def transform(document)
       raise NotImplementedError

--- a/spec/indexer_spec.rb
+++ b/spec/indexer_spec.rb
@@ -47,6 +47,19 @@ describe AgnosticBackend::Indexer do
     end
   end
 
+  describe '#generate_document' do
+    let(:document) { double('IndexableGeneratedDocument') }
+    let(:prepared_doc) { double('PreparedDocument') }
+    let(:transformed_doc) { double('TransformedDoc') }
+    let(:indexable) { double("Indexable1", generate_document: document) }
+
+    it 'prepares and transforms the indexables generated document' do
+      expect(subject).to receive(:prepare).with(document).and_return(prepared_doc)
+      expect(subject).to receive(:transform).with(prepared_doc).and_return(transformed_doc)
+      expect(subject.generate_document(indexable)).to eq transformed_doc
+    end
+  end
+
   describe '#delete' do
     let(:document_id) { 1 }
     it 'should forward to #delete_all and return its value' do


### PR DESCRIPTION
Also expose publish and publish_all public methods. This is useful when we need to do some pre-processing before publishing our documents to remote backend. 
