### PR TITLE
Duck typing for trigger index notification strategy

### DIFF
--- a/lib/agnostic_backend/indexable/indexable.rb
+++ b/lib/agnostic_backend/indexable/indexable.rb
@@ -123,7 +123,7 @@ module AgnosticBackend
         return unless respond_to? :_index_root_notifiers
         _index_root_notifiers.each do |index_name, block|
           obj = instance_eval &block
-          obj = [obj] unless obj.is_a? Enumerable
+          obj = [obj] unless obj.respond_to? :each
           obj.each { |o| o.index_object(index_name) if o.present? }
         end
       end


### PR DESCRIPTION
The reason behind this change is the introduction (for Rails 4) of `CollectionProxy` 
in `ActiveRecord` `:has_many` associations.

For example:
```ruby
class Task < ActiveRecord::Base
  belongs_to :workflow, class_name: 'Workflow'
end

class Workflow < ActiveRecord::Base
  has_many :tasks, class_name: 'Task'

   define_index_notifier { tasks }
end
```

The block `{ tasks }` will be evaluated to a `Task::ActiveRecord_Associations_CollectionProxy` 
which is not an `Enumerable`.

We changed the behaviour in order to rely on the object quacking to `:each`. 